### PR TITLE
Implements `Authorization Middleware` to give access or not to a api route based on `user role`

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -12,7 +12,7 @@ async function main() {
     },
   });
 
-  await prismaClient.role.create({
+  const userRole = await prismaClient.role.create({
     data: {
       name: "user",
     },
@@ -43,14 +43,24 @@ async function main() {
     ],
   });
 
-  await prismaClient.user.create({
-    data: {
-      email: "admin@email.com",
-      name: "Admin User",
-      passwordHash:
-        "$2a$12$cf1tYwdsYYkO6wUeDPOElegUY/6X2Iw/55XgR6B/NxBbnDcVyTzB.", // 123456
-      roleId: adminRole.id,
-    },
+  const defaultPassword =
+    "$2a$12$cf1tYwdsYYkO6wUeDPOElegUY/6X2Iw/55XgR6B/NxBbnDcVyTzB."; // 123456
+
+  await prismaClient.user.createMany({
+    data: [
+      {
+        email: "admin@email.com",
+        name: "Admin User",
+        passwordHash: defaultPassword,
+        roleId: adminRole.id,
+      },
+      {
+        email: "user@email.com",
+        name: "Normal User",
+        passwordHash: defaultPassword,
+        roleId: userRole.id,
+      },
+    ],
   });
 
   console.log("Seeds created successfully!");

--- a/src/application/controllers/ListRolePermissionsController.ts
+++ b/src/application/controllers/ListRolePermissionsController.ts
@@ -1,0 +1,18 @@
+import type { IController, IResponse } from "../interfaces/IController";
+import type { IRequest } from "../interfaces/IRequest";
+import type { ListRolePermissionsUseCase } from "../useCases/ListRolePermissionsUseCase";
+
+export class ListRolePermissionsController implements IController {
+  constructor(
+    private readonly listRolePermissionsUseCase: ListRolePermissionsUseCase
+  ) {}
+
+  async handle(_request: IRequest): Promise<IResponse> {
+    const { rolePermissions } = await this.listRolePermissionsUseCase.execute();
+
+    return {
+      body: { rolePermissions },
+      statusCode: 200,
+    };
+  }
+}

--- a/src/application/middlewares/AuthenticationMiddleware.ts
+++ b/src/application/middlewares/AuthenticationMiddleware.ts
@@ -1,10 +1,6 @@
-import { verify } from "jsonwebtoken";
-import type {
-  IData,
-  IMiddleware,
-  IResponse,
-} from "../application/interfaces/IMiddleware";
-import type { IRequest } from "../application/interfaces/IRequest";
+import { type JwtPayload, verify } from "jsonwebtoken";
+import type { IData, IMiddleware, IResponse } from "../interfaces/IMiddleware";
+import type { IRequest } from "../interfaces/IRequest";
 
 export class AuthenticationMiddleware implements IMiddleware {
   async handle(request: IRequest): Promise<IResponse | IData> {
@@ -24,7 +20,7 @@ export class AuthenticationMiddleware implements IMiddleware {
         throw new Error();
       }
 
-      const payload = verify(token, process.env.JWT_SECRET_KEY);
+      const payload = verify(token, process.env.JWT_SECRET_KEY) as JwtPayload;
 
       return {
         data: {

--- a/src/application/middlewares/AuthorizationMiddleware.ts
+++ b/src/application/middlewares/AuthorizationMiddleware.ts
@@ -1,0 +1,50 @@
+import type { IData, IMiddleware, IResponse } from "../interfaces/IMiddleware";
+import type { IRequest } from "../interfaces/IRequest";
+import type { GetRolePermissionsUseCase } from "../useCases/GetRolePermissionsUseCase";
+
+export interface IOptions {
+  operator: "AND" | "OR";
+}
+
+export class AuthorizationMiddleware implements IMiddleware {
+  constructor(
+    private readonly requiredPermissions: string[],
+    private readonly getRolePermissionUseCase: GetRolePermissionsUseCase,
+    private readonly options?: IOptions
+  ) {}
+
+  async handle(request: IRequest): Promise<IResponse | IData> {
+    const { user } = request;
+
+    if (!user) {
+      return {
+        statusCode: 401,
+        body: {
+          error: "Access Denied.",
+        },
+      };
+    }
+
+    const { permissionCodes } = await this.getRolePermissionUseCase.execute({
+      roleId: user.role,
+    });
+
+    const operatorFn = this.options?.operator === "AND" ? "every" : "some";
+    const userHasPermission = this.requiredPermissions[operatorFn](
+      (requiredPermission) => permissionCodes.includes(requiredPermission)
+    );
+
+    if (!userHasPermission) {
+      return {
+        statusCode: 403,
+        body: {
+          error: "Access Denied.",
+        },
+      };
+    }
+
+    return {
+      data: {},
+    };
+  }
+}

--- a/src/application/useCases/GetRolePermissionsUseCase.ts
+++ b/src/application/useCases/GetRolePermissionsUseCase.ts
@@ -1,0 +1,21 @@
+import type { IUseCase } from "../interfaces/IUseCase";
+import { prismaClient } from "../libs/prismaClient";
+
+interface IInput {
+  roleId: string;
+}
+
+export class GetRolePermissionsUseCase implements IUseCase {
+  async execute({ roleId }: IInput) {
+    const rolePermissions = await prismaClient.rolePermission.findMany({
+      where: { roleId },
+      select: { permissionCode: true },
+    });
+
+    const permissionCodes = rolePermissions.map(
+      (rolePermissions) => rolePermissions.permissionCode
+    );
+
+    return { permissionCodes };
+  }
+}

--- a/src/application/useCases/ListRolePermissionsUseCase.ts
+++ b/src/application/useCases/ListRolePermissionsUseCase.ts
@@ -1,0 +1,45 @@
+import type { IUseCase } from "../interfaces/IUseCase";
+import { prismaClient } from "../libs/prismaClient";
+
+interface IOutput {
+  rolePermissions: Array<{
+    permissionId: string;
+    permissionCode: string;
+    roleId: string;
+    roleName: string;
+  }>;
+}
+
+export class ListRolePermissionsUseCase implements IUseCase {
+  async execute(): Promise<IOutput> {
+    const rolePermissions = await prismaClient.rolePermission.findMany({
+      select: {
+        roleId: true,
+        permissionCode: true,
+        role: {
+          select: {
+            name: true,
+          },
+        },
+        permission: {
+          select: {
+            id: true,
+          },
+        },
+      },
+    });
+
+    const formattedRolePermissions = rolePermissions.map(
+      ({ permissionCode, permission, role, roleId }) => ({
+        permissionId: permission.id,
+        permissionCode,
+        roleId,
+        roleName: role.name,
+      })
+    );
+
+    return {
+      rolePermissions: formattedRolePermissions,
+    };
+  }
+}

--- a/src/application/useCases/SignInUseCase.ts
+++ b/src/application/useCases/SignInUseCase.ts
@@ -30,7 +30,10 @@ export class SignInUseCase implements IUseCase {
 
     const accessToken = sign(
       { sub: user.id, role: user.roleId },
-      process.env.JWT_SECRET_KEY
+      process.env.JWT_SECRET_KEY,
+      {
+        expiresIn: "1d",
+      }
     );
 
     return {

--- a/src/factories/makeAuthenticationMiddleware.ts
+++ b/src/factories/makeAuthenticationMiddleware.ts
@@ -1,4 +1,4 @@
-import { AuthenticationMiddleware } from "../middlewares/AuthenticationMiddleware";
+import { AuthenticationMiddleware } from "../application/middlewares/AuthenticationMiddleware";
 
 export function makeAuthenticationMiddleware() {
   return new AuthenticationMiddleware();

--- a/src/factories/makeAuthorizationMiddleware.ts
+++ b/src/factories/makeAuthorizationMiddleware.ts
@@ -1,0 +1,18 @@
+import {
+  AuthorizationMiddleware,
+  type IOptions,
+} from "../application/middlewares/AuthorizationMiddleware";
+import { makeGetRolePermissionUseCase } from "./makeGetRolePermissionUseCase";
+
+export function makeAuthorizationMiddleware(
+  requiredPermissions: string[],
+  options?: IOptions
+) {
+  const getRolePermissionUseCase = makeGetRolePermissionUseCase();
+
+  return new AuthorizationMiddleware(
+    requiredPermissions,
+    getRolePermissionUseCase,
+    options
+  );
+}

--- a/src/factories/makeGetRolePermissionUseCase.ts
+++ b/src/factories/makeGetRolePermissionUseCase.ts
@@ -1,0 +1,5 @@
+import { GetRolePermissionsUseCase } from "../application/useCases/GetRolePermissionsUseCase";
+
+export function makeGetRolePermissionUseCase() {
+  return new GetRolePermissionsUseCase();
+}

--- a/src/factories/makeListRolePermissionsContoller.ts
+++ b/src/factories/makeListRolePermissionsContoller.ts
@@ -1,0 +1,7 @@
+import { ListRolePermissionsController } from "../application/controllers/ListRolePermissionsController";
+import { makeListRolePermissionsUseCase } from "./makeListRolePermissionsUseCase";
+
+export function makeListRolePermissionsController() {
+  const listRolePermissionsUseCase = makeListRolePermissionsUseCase();
+  return new ListRolePermissionsController(listRolePermissionsUseCase);
+}

--- a/src/factories/makeListRolePermissionsUseCase.ts
+++ b/src/factories/makeListRolePermissionsUseCase.ts
@@ -1,0 +1,5 @@
+import { ListRolePermissionsUseCase } from "../application/useCases/ListRolePermissionsUseCase";
+
+export function makeListRolePermissionsUseCase() {
+  return new ListRolePermissionsUseCase();
+}

--- a/src/server/adapters/middlewareAdapter.ts
+++ b/src/server/adapters/middlewareAdapter.ts
@@ -12,7 +12,8 @@ export function middlewareAdapter(middleware: IMiddleware) {
 
     if ("statusCode" in middlewareResult) {
       const { body, statusCode } = middlewareResult;
-      return response.json(body).status(statusCode);
+      response.json(body).status(statusCode);
+      return;
     }
 
     request.metadata = {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,6 +1,8 @@
 import express from "express";
 import { makeAuthenticationMiddleware } from "../factories/makeAuthenticationMiddleware";
+import { makeAuthorizationMiddleware } from "../factories/makeAuthorizationMiddleware";
 import { makeListLeadsController } from "../factories/makeListLeadsController";
+import { makeListRolePermissionsController } from "../factories/makeListRolePermissionsContoller";
 import { makeSignInController } from "../factories/makeSignInController";
 import { makeSignUpController } from "../factories/makeSignUpController";
 import { middlewareAdapter } from "./adapters/middlewareAdapter";
@@ -16,6 +18,13 @@ app.get(
   mountUrl("/leads"),
   middlewareAdapter(makeAuthenticationMiddleware()),
   routeAdapter(makeListLeadsController())
+);
+
+app.get(
+  mountUrl("/role-permissions"),
+  middlewareAdapter(makeAuthenticationMiddleware()),
+  middlewareAdapter(makeAuthorizationMiddleware(["permission:read"])),
+  routeAdapter(makeListRolePermissionsController())
 );
 
 app.listen(3000, () => {


### PR DESCRIPTION
## Done
- Moved `/src/middlewares` folder to `/src/application/middlewares`
- Updated `seed.ts` file to create a normal user account
- Updated `SignInUseCase` to expire JWT token in one day
- Created `GetRolePermissionUseCase` to get permissions by role id
- Created `ListRolePermissionsUseCase`
- Created `ListRolePermissionsController` receiving `listRolePermissionUseCase` as dependency injection
- Created and used `AuthorizationMiddleware` to give access or not to a api route based on the user role (accessible in the jwt payload)

## Usage
```ts
// server/index.ts
// imagine if makeListRolePermissionsController() returns information that only users with "permission:read" can access

app.get(
  'private-route/only-admin',
  middlewareAdapter(makeAuthenticationMiddleware()), // guarantees that only signed users can call this route
  middlewareAdapter(makeAuthorizationMiddleware(["permission:read"])), // guarantees that only users with "permission:read" can call this route
  routeAdapter(makeListRolePermissionsController())
);
```

## Preview
[Gravação de tela de 15-11-2024 12:03:04.webm](https://github.com/user-attachments/assets/4a6b6e3a-6af0-455f-9d6e-90384cd2db8c)


